### PR TITLE
Rename deprecated macro assert_msg to avoid possible conflicts

### DIFF
--- a/limbo/algorithms/coloring/BacktrackColoring.h
+++ b/limbo/algorithms/coloring/BacktrackColoring.h
@@ -127,7 +127,7 @@ double BacktrackColoring<GraphType>::coloring()
 
 	// verify solution  
 	actual_cost = this->calc_cost(this->m_vColor);
-	//assert_msg(best_cost == actual_cost, "best_cost = " << best_cost << ", actual cost = " << actual_cost);
+	//limbo_assert_msg(best_cost == actual_cost, "best_cost = " << best_cost << ", actual cost = " << actual_cost);
 #ifdef DEBUG_LIWEI
     limboPrint(kDEBUG, "Graph has %lu nodes, with backtracking cost %g\n", boost::num_vertices(this->m_graph), best_cost);
 #endif
@@ -194,7 +194,7 @@ void BacktrackColoring<GraphType>::coloring_kernel(vector<int8_t>& vBestColor, v
 			if (u < v) // only check parent node in the recursion tree 
 			{
 				std::pair<graph_edge_type, bool> e = boost::edge(u, v, this->m_graph);
-				assert_msg(e.second, "failed to find edge with " << u << "--" << v);
+				limbo_assert_msg(e.second, "failed to find edge with " << u << "--" << v);
 				edge_weight_type w = boost::get(boost::edge_weight, this->m_graph, e.first);
 				if (w >= 0) // conflict edge 
             		delta_cost += (vColor[u] == c)*w;

--- a/limbo/algorithms/coloring/Coloring.h
+++ b/limbo/algorithms/coloring/Coloring.h
@@ -423,7 +423,7 @@ void Coloring<GraphType>::check_edge_weight(typename Coloring<GraphType>::graph_
 	for (boost::tie(ei, eie) = boost::edges(g); ei != eie; ++ei)
 	{
 		edge_weight_type w = boost::get(boost::edge_weight, m_graph, *ei);
-        assert_msg(w >= lb && w <= ub, "edge weight out of range: " << w);
+        limbo_assert_msg(w >= lb && w <= ub, "edge weight out of range: " << w);
     }
 }
 

--- a/limbo/algorithms/coloring/GraphSimplification.h
+++ b/limbo/algorithms/coloring/GraphSimplification.h
@@ -537,7 +537,7 @@ bool GraphSimplification<GraphType>::simplified_graph_component(uint32_t comp_id
 				else if (v >= u) continue; // avoid duplicate 
 				else if (ap && !mOrig2Simpl.count(u)) continue; // skip vertex that is not in component 
 				//else if (u == v) continue;
-				assert_msg(u != v, u << " == " << v);
+				limbo_assert_msg(u != v, u << " == " << v);
 
 				std::pair<graph_edge_type, bool> e = boost::edge(vc, uc, m_graph);
 				assert(e.second);
@@ -550,7 +550,7 @@ bool GraphSimplification<GraphType>::simplified_graph_component(uint32_t comp_id
 					std::cout << "usg : " << usg <<  "  vsg : " << vsg << std::endl;
 				}
 #endif
-				assert_msg(usg != vsg, u << "==" << v << ": " << usg << " == " << vsg);
+				limbo_assert_msg(usg != vsg, u << "==" << v << ": " << usg << " == " << vsg);
 				
 				std::pair<graph_edge_type, bool> esg = boost::edge(vsg, usg, sg);
 				if (!esg.second)
@@ -1335,7 +1335,7 @@ void GraphSimplification<GraphType>::recover_biconnected_component(std::vector<s
 			int8_t color = mColor[comp][mApOrig2Simpl[comp][vap]];
 			if (itc == sComp.begin())
 				prev_color = color;
-			else assert_msg(prev_color == color, 
+			else limbo_assert_msg(prev_color == color, 
 					vap << ": " << "comp " << comp << ", c[" << mApOrig2Simpl[comp][vap] << "] = " << color << "; " 
 					<< "prev_color = " << prev_color);
 		}
@@ -1509,7 +1509,7 @@ void GraphSimplification<GraphType>::write_simplified_graph_dot(std::string cons
 				graph_vertex_type mv1 = boost::source(e, sg);
 				graph_vertex_type mv2 = boost::target(e, sg);
 				int32_t w = boost::get(boost::edge_weight, sg, e);
-				assert_msg(mv1 != mv2, mv1 << " == " << mv2);
+				limbo_assert_msg(mv1 != mv2, mv1 << " == " << mv2);
 
 				char buf[256];
 				if (w >= 0)

--- a/limbo/algorithms/coloring/LPColoring.h
+++ b/limbo/algorithms/coloring/LPColoring.h
@@ -405,7 +405,7 @@ void LPColoring<GraphType>::set_optimize_model(vector<GRBVar>& vColorBits, vecto
         uint32_t bitIdxT = t<<1;
 
         edge_weight_type w = this->edge_weight(e);
-        assert_msg(w > 0, "no stitch edge allowed, positive edge weight expected: " << w);
+        limbo_assert_msg(w > 0, "no stitch edge allowed, positive edge weight expected: " << w);
 
         sprintf(buf, "R%u", m_constrs_num++);  
         optModel.addConstr(
@@ -570,7 +570,7 @@ void LPColoring<GraphType>::solve_model(GRBModel& optModel)
         sprintf(buf, "%u.ilp", m_lp_iters);
         optModel.write(buf);
     }
-    assert_msg(optStatus != GRB_INFEASIBLE, "model is infeasible");
+    limbo_assert_msg(optStatus != GRB_INFEASIBLE, "model is infeasible");
     ++m_lp_iters;
 }
 

--- a/limbo/geometry/Polygon2Rectangle.h
+++ b/limbo/geometry/Polygon2Rectangle.h
@@ -166,7 +166,7 @@ class Polygon2Rectangle
 					break;
 				}
 			}
-			assert_msg(input_last != input_end, "failed to find input_last, maybe too few points");
+			limbo_assert_msg(input_last != input_end, "failed to find input_last, maybe too few points");
 			if (is_equal_type()(*input_begin, *input_last)) ++input_begin; // skip identical first and last points 
 			// use only operator++ so that just forward_iteartor is enough
 			for (InputIterator itPrev = input_begin; itPrev != input_end; ++itPrev)
@@ -340,7 +340,7 @@ class Polygon2Rectangle
                             break; 
                         }
                         default:
-                            assert_msg(0, "should not reach here " << m_slicing_orient); 
+                            limbo_assert_msg(0, "should not reach here " << m_slicing_orient); 
                     }
 				}
 				// insert or remove point 

--- a/limbo/geometry/Polygon2RectangleVec.h
+++ b/limbo/geometry/Polygon2RectangleVec.h
@@ -283,7 +283,7 @@ class Polygon2Rectangle<std::vector<PointType>, std::vector<RectangleType> >
                             break; 
                         }
                         default:
-                            assert_msg(0, "should not reach here " << m_slicing_orient); 
+                            limbo_assert_msg(0, "should not reach here " << m_slicing_orient); 
                     }
 				}
 				// insert or remove point 

--- a/limbo/parsers/gdsii/stream/GdsDriver.h
+++ b/limbo/parsers/gdsii/stream/GdsDriver.h
@@ -205,19 +205,19 @@ void GdsDriver::general_cbk(string const& ascii_record_type, string const&, Cont
 	else if (ascii_record_type == "BOUNDARY" || ascii_record_type == "BOX") // BOUNDARY and BOX are generalized to BOUNDARY
 	{
 		m_current = "BOUNDARY";
-		assert_msg(!m_lib.vCell.empty(), ascii_record_type << " block must be in a BGNSTR block");
+		limbo_assert_msg(!m_lib.vCell.empty(), ascii_record_type << " block must be in a BGNSTR block");
 		m_lib.vCell.back().vBoundary.push_back(GdsBoundary());
 	}
 	else if (ascii_record_type == "TEXT")
 	{
 		m_current = "TEXT";
-		assert_msg(!m_lib.vCell.empty(), ascii_record_type << " block must be in a BGNSTR block");
+		limbo_assert_msg(!m_lib.vCell.empty(), ascii_record_type << " block must be in a BGNSTR block");
 		m_lib.vCell.back().vText.push_back(GdsText());
 	}
 	else if (ascii_record_type == "SREF")
 	{
 		m_current = "SREF";
-		assert_msg(!m_lib.vCell.empty(), ascii_record_type << " block must be in a BGNSTR block");
+		limbo_assert_msg(!m_lib.vCell.empty(), ascii_record_type << " block must be in a BGNSTR block");
 		m_lib.vCell.back().vSref.push_back(GdsSref());
 	}
 	else if (ascii_record_type == "LAYER")
@@ -261,7 +261,7 @@ void GdsDriver::general_cbk(string const& ascii_record_type, string const&, Cont
 	{
 		if (m_current == "BOUNDARY")
 		{
-			assert_msg((vData.size() % 2) == 0 && vData.size() > 4, "invalid size of data array: " << vData.size());
+			limbo_assert_msg((vData.size() % 2) == 0 && vData.size() > 4, "invalid size of data array: " << vData.size());
 			for (uint32_t i = 0; i < vData.size(); i += 2)
 			{
 				vector<int32_t> point (2);
@@ -272,44 +272,44 @@ void GdsDriver::general_cbk(string const& ascii_record_type, string const&, Cont
 		}
 		else if (m_current == "TEXT")
 		{
-			assert_msg(vData.size() == 2, "invalid size of data array for " 
+			limbo_assert_msg(vData.size() == 2, "invalid size of data array for " 
 					<< m_current << ": " << vData.size());
 			m_lib.vCell.back().vText.back().position.assign(vData.begin(), vData.end());
 		}
 		else if (m_current == "SREF")
 		{
-			assert_msg(vData.size() == 2, "invalid size of data array for " 
+			limbo_assert_msg(vData.size() == 2, "invalid size of data array for " 
 					<< m_current << ": " << vData.size());
 			m_lib.vCell.back().vSref.back().position.assign(vData.begin(), vData.end());
 		}
-		else assert_msg(0, "record XY should only appear in BOUNDARY, BOX, TEXT, SREF");
+		else limbo_assert_msg(0, "record XY should only appear in BOUNDARY, BOX, TEXT, SREF");
 	}
 	else if (ascii_record_type == "STRING")
 	{
-		assert_msg(m_current == "TEXT", "record type STRING must appear in TEXT block rather than " << m_current);
+		limbo_assert_msg(m_current == "TEXT", "record type STRING must appear in TEXT block rather than " << m_current);
 		m_lib.vCell.back().vText.back().content.assign(vData.begin(), vData.end());
 	}
 	else if (ascii_record_type == "ENDEL")
 	{
-		assert_msg(m_current == "BOUNDARY" || m_current == "TEXT"
+		limbo_assert_msg(m_current == "BOUNDARY" || m_current == "TEXT"
 				|| m_current == "SREF", 
 				"currently only support BOUNDARY, BOX, and TEXT");
 		m_current = "CELL"; // go back to upper 
 	}
 	else if (ascii_record_type == "ENDSTR")
 	{
-		assert_msg(m_current == "CELL", "BGNSTR and ENDSTR should be in pair");
+		limbo_assert_msg(m_current == "CELL", "BGNSTR and ENDSTR should be in pair");
 		m_current = "LIBRARY"; // go back to upper 
 	}
 	else if (ascii_record_type == "ENDLIB")
 	{
-		assert_msg(m_current == "LIBRARY", "BGNLIB and ENDLIB should be in pair");
+		limbo_assert_msg(m_current == "LIBRARY", "BGNLIB and ENDLIB should be in pair");
 		m_current = "HEADER"; 
 		// call db 
 		m_db.add_gds_lib(m_lib);
 		m_lib.reset();
 	}
-	else assert_msg(0, "unsupported record type: " << ascii_record_type);
+	else limbo_assert_msg(0, "unsupported record type: " << ascii_record_type);
 }
 
 /// @brief API function for GdsDriver

--- a/limbo/preprocessor/AssertMsg.h
+++ b/limbo/preprocessor/AssertMsg.h
@@ -2,7 +2,7 @@
  * @file   AssertMsg.h
  * @brief  assertion with message 
  *
- * macro: assert_msg (deprecated)
+ * macro: limbo_assert_msg (deprecated)
  *
  * attribute: assertion with message. 
  *            if defined NO_LIMBO_ASSERTION, call assert in STL; 
@@ -24,14 +24,14 @@
 #include <limbo/preprocessor/Msg.h>
 
 /// deprecated
-/// @def assert_msg(condition, message)
+/// @def limbo_assert_msg(condition, message)
 /// @brief assertion with message 
 /// 
 /// I leave it here for backward compatibility. 
 /// custom assertion with message. 
-/// example usage: assert_msg(condition, "this is " << value << " for test");
+/// example usage: limbo_assert_msg(condition, "this is " << value << " for test");
 #ifndef NO_LIMBO_ASSERTION
-#define assert_msg(condition, message) \
+#define limbo_assert_msg(condition, message) \
     do { \
         if (! (condition)) { \
             std::cerr << __FILE__ << ":" << __LINE__ << ": " << __PRETTY_FUNCTION__ << ": Assertion `" << #condition << "' failed: " << message << std::endl; \
@@ -39,7 +39,7 @@
         } \
     } while (false)
 #else
-#define assert_msg(condition, message) \
+#define limbo_assert_msg(condition, message) \
 	do { \
 		assert(condition); \
 	} while (false)

--- a/limbo/programoptions/ProgramOptions.h
+++ b/limbo/programoptions/ProgramOptions.h
@@ -520,7 +520,7 @@ class ProgramOptions
          */
         inline void print_space(std::ostream& os, unsigned num) const 
         {
-            assert_msg(num < 1000, "num out of bounds: " << num);
+            limbo_assert_msg(num < 1000, "num out of bounds: " << num);
             os << std::string (num, ' ');
         }
 

--- a/limbo/solvers/api/GurobiApi.h
+++ b/limbo/solvers/api/GurobiApi.h
@@ -304,7 +304,7 @@ struct GurobiFileApi
 		// read rpt 
 		{
 			std::ifstream solFile ((fileName+".sol").c_str(), std::ifstream::in);
-			if (!solFile.good()) BOOST_ASSERT_MSG(false, ("failed to open " + fileName + ".sol").c_str());
+			if (!solFile.good()) BOOST_limbo_assert_msg(false, ("failed to open " + fileName + ".sol").c_str());
 
 			std::string var;
 			double value;

--- a/limbo/solvers/lpmcf/Lgf.h
+++ b/limbo/solvers/lpmcf/Lgf.h
@@ -236,7 +236,7 @@ class Lgf
 					break;
 			}
 
-			assert_msg(status == alg_type::OPTIMAL, "failed to achieve OPTIMAL solution");
+			limbo_assert_msg(status == alg_type::OPTIMAL, "failed to achieve OPTIMAL solution");
 #endif 
 			// 4. update solution 
 			if (status == alg_type::OPTIMAL)

--- a/limbo/solvers/lpmcf/LpDualMcf.h
+++ b/limbo/solvers/lpmcf/LpDualMcf.h
@@ -248,18 +248,18 @@ class LpDualMcf : public Lgf<T>, public LpParser::LpDataBase
                 lb = limbo::lowest<value_type>();
             if (r >= (double)std::numeric_limits<value_type>::max())
                 ub = std::numeric_limits<value_type>::max();
-			assert_msg(lb <= ub, "failed to add bound " << lb << " <= " << xi << " <= " << ub);
+			limbo_assert_msg(lb <= ub, "failed to add bound " << lb << " <= " << xi << " <= " << ub);
 
 			// no variables with the same name is allowed 
 			BOOST_AUTO(found, m_hVariable.find(xi));
 			if (found == m_hVariable.end())
-				assert_msg(m_hVariable.insert(make_pair(xi, variable_type(xi, lb, ub, 0))).second,
+				limbo_assert_msg(m_hVariable.insert(make_pair(xi, variable_type(xi, lb, ub, 0))).second,
 						"failed to insert variable " << xi << " to hash table");
 			else 
 			{
 				found->second.range.first = std::max(found->second.range.first, (value_type)lb);
 				found->second.range.second = std::min(found->second.range.second, (value_type)ub);
-				assert_msg(found->second.range.first <= found->second.range.second, 
+				limbo_assert_msg(found->second.range.first <= found->second.range.second, 
 						"failed to set bound " << found->second.range.first << " <= " << xi << " <= " << found->second.range.second);
 			}
 			// if user set bounds to variables 
@@ -336,7 +336,7 @@ class LpDualMcf : public Lgf<T>, public LpParser::LpDataBase
 		{
 			BOOST_AUTO(found, m_hConstraint.find(make_pair(xi, xj)));
 			if (found == m_hConstraint.end())
-				assert_msg(m_hConstraint.insert(
+				limbo_assert_msg(m_hConstraint.insert(
 							make_pair(
 								make_pair(xi, xj), 
 								constraint_type(xi, xj, cij)
@@ -358,7 +358,7 @@ class LpDualMcf : public Lgf<T>, public LpParser::LpDataBase
 			if (w == 0) return;
 
 			BOOST_AUTO(found, m_hVariable.find(xi));
-			assert_msg(found != m_hVariable.end(), "failed to add objective " << w << " " << xi);
+			limbo_assert_msg(found != m_hVariable.end(), "failed to add objective " << w << " " << xi);
 
 			found->second.weight += w;
 		}
@@ -410,7 +410,7 @@ class LpDualMcf : public Lgf<T>, public LpParser::LpDataBase
 		value_type solution(string const& xi) const 
 		{
 			BOOST_AUTO(found, m_hVariable.find(xi));
-			assert_msg(found != m_hVariable.end(), "failed to find variable " << xi);
+			limbo_assert_msg(found != m_hVariable.end(), "failed to find variable " << xi);
 
 			return found->second.value;
 		}
@@ -531,8 +531,8 @@ class LpDualMcf : public Lgf<T>, public LpParser::LpDataBase
 				constraint_type& constraint = it->second;
 				BOOST_AUTO(found1, m_hVariable.find(constraint.variable.first));
 				BOOST_AUTO(found2, m_hVariable.find(constraint.variable.second));
-				assert_msg(found1 != m_hVariable.end(), "failed to find variable1 " << constraint.variable.first << " in preparing arcs"); 
-				assert_msg(found2 != m_hVariable.end(), "failed to find variable2 " << constraint.variable.second << " in preparing arcs"); 
+				limbo_assert_msg(found1 != m_hVariable.end(), "failed to find variable1 " << constraint.variable.first << " in preparing arcs"); 
+				limbo_assert_msg(found2 != m_hVariable.end(), "failed to find variable2 " << constraint.variable.second << " in preparing arcs"); 
 
 				variable_type const& variable1 = found1->second;
 				variable_type const& variable2 = found2->second;
@@ -620,7 +620,7 @@ class LpDualMcf : public Lgf<T>, public LpParser::LpDataBase
 					break;
 			}
 
-			assert_msg(status == alg_type::OPTIMAL, "failed to achieve OPTIMAL solution");
+			limbo_assert_msg(status == alg_type::OPTIMAL, "failed to achieve OPTIMAL solution");
 #endif 
 			// 4. update solution 
 			if (status == alg_type::OPTIMAL)

--- a/test/programoptions/test_ProgramOptions.cpp
+++ b/test/programoptions/test_ProgramOptions.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
         cout << *it << " ";
     cout << endl;
 
-    assert_msg(help == false, "help turned to true");
+    limbo_assert_msg(help == false, "help turned to true");
 
     return 0;
 }

--- a/test/string/test_string.cpp
+++ b/test/string/test_string.cpp
@@ -21,9 +21,9 @@ int main()
 	string s1 = "limbo2343slimbo";
 	string s2 = "LiMbo2343SliMbo";
 
-	assert_msg(limbo::toupper(s1) == "LIMBO2343SLIMBO", "limbo::toupper failed");
-	assert_msg(limbo::tolower(s2) == "limbo2343slimbo", "limbo::tolower failed");
-	assert_msg(limbo::iequals(s1, s2), "limbo::iequals failed");
+	limbo_assert_msg(limbo::toupper(s1) == "LIMBO2343SLIMBO", "limbo::toupper failed");
+	limbo_assert_msg(limbo::tolower(s2) == "limbo2343slimbo", "limbo::tolower failed");
+	limbo_assert_msg(limbo::iequals(s1, s2), "limbo::iequals failed");
 
 	string tmp;
 	tmp = limbo::to_string(limbo::lowest<int>());


### PR DESCRIPTION
# Macro Definition Conflicts

Just downloaded the latest `torch 2.1` and found a weird error when compiling a placer:
```
/some/path/python3.11/site-packages/torch/include/ATen/core/interned_strings.h:354:1: error: macro "assert_msg" requires 2 arguments, but only 1 given
  354 | FORALL_NS_SYMBOLS(DEFINE_SYMBOL)
      | ^~~~~~~~~~~~~~~
``` 
It seems that the macro `assert_msg` defined in `limbo/preprocessor/AssertMsg.h:34` is conflict with the one in `torch 2.1`. I have not checked whether it is `torch 2.1` that introduced this macro or something happened accidentally, but renaming all `assert_msg` to `limbo_assert_msg` indeed works. Since the macro `assert_msg` is marked `deprecated` in `AssertMsg.h`, I presume changing its name would have negligible effects.