### PR TITLE
C++17 fix

### DIFF
--- a/limbo/thirdparty/lemon/lemon/bits/array_map.h
+++ b/limbo/thirdparty/lemon/lemon/bits/array_map.h
@@ -74,7 +74,7 @@ namespace lemon {
     // The MapBase of the Map which imlements the core regisitry function.
     typedef typename Notifier::ObserverBase Parent;
 
-    typedef std::allocator<Value> Allocator;
+    typedef std::allocator_traits<Value> Allocator;
 
   public:
 

--- a/limbo/thirdparty/lemon/lemon/bits/array_map.h
+++ b/limbo/thirdparty/lemon/lemon/bits/array_map.h
@@ -74,7 +74,11 @@ namespace lemon {
     // The MapBase of the Map which imlements the core regisitry function.
     typedef typename Notifier::ObserverBase Parent;
 
+#if __cplusplus >= 201703L
+    typedef std::allocator_traits<Value> Allocator;
+#else
     typedef std::allocator<Value> Allocator;
+#endif
 
   public:
 


### PR DESCRIPTION
C++ 17 and upwards requires std::allocator to be replaced with std::allocator_traits, in order to compile successfully.